### PR TITLE
support optional items in lists

### DIFF
--- a/rlp/sedes/lists.py
+++ b/rlp/sedes/lists.py
@@ -23,10 +23,12 @@ def is_sequence(obj):
 
 
 class List(list):
+
     """A sedes for lists, implemented as a list of other sedes objects."""
 
-    def __init__(self, elements=[]):
+    def __init__(self, elements=[], strict=True):
         super(List, self).__init__()
+        self.strict = strict
         for e in elements:
             if is_sedes(e):
                 self.append(e)
@@ -39,7 +41,7 @@ class List(list):
     def serialize(self, obj):
         if not is_sequence(obj):
             raise SerializationError('Can only serialize sequences', obj)
-        if len(self) != len(obj):
+        if self.strict and len(self) != len(obj):
             raise SerializationError('List has wrong length', obj)
         return [sedes.serialize(element)
                 for element, sedes in zip(obj, self)]


### PR DESCRIPTION
```
In [1]: import rlp
In [2]: sedes = rlp.sedes.List([rlp.sedes.big_endian_int, rlp.sedes.big_endian_int], strict=False)
In [3]: r2 = rlp.encode([1], sedes=sedes)
In [4]: r = rlp.encode([1,2], sedes=sedes)
In [5]: rlp.decode(r, sedes=sedes)
Out[5]: [1, 2]
In [6]: rlp.decode(r2, sedes=sedes)
Out[6]: [1]
```