### PR TITLE
fix rlp.compare_length

### DIFF
--- a/rlp/codec.py
+++ b/rlp/codec.py
@@ -297,7 +297,7 @@ def compare_length(rlpdata, length):
     assert _typ is list
     lenlist = 0
     if rlpdata == EMPTYLIST:
-        return 1 if length > 0 else -1 if length < 0 else 0
+        return -1 if length > 0 else 1 if length < 0 else 0
     while 1:
         if lenlist > length:
             return 1

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -1,0 +1,12 @@
+import rlp
+
+def test_compare_length():
+    data = rlp.encode([1,2,3,4,5])
+    assert rlp.compare_length(data, 100) == -1
+    assert rlp.compare_length(data, 5) == 0
+    assert rlp.compare_length(data, 1) == 1
+
+    data = rlp.encode([])
+    assert rlp.compare_length(data, 100) == -1
+    assert rlp.compare_length(data, 0) == 0
+    assert rlp.compare_length(data, -1) == 1


### PR DESCRIPTION
The compare semantic is left compare with right, return -1 when left is shorter/smaller.

While `rlp.compare_length` behaves correctly when the first argument is non-empty list, it behaves the opposite when the first argument is empty list.