### PR TITLE
Use python2 compatible metaclass syntax for ABCMeta based class

### DIFF
--- a/rlp/utils_py3.py
+++ b/rlp/utils_py3.py
@@ -3,7 +3,7 @@ import binascii
 from math import ceil
 
 
-class Atomic(metaclass = abc.ABCMeta):
+class Atomic(type.__new__(abc.ABCMeta, 'metaclass', (), {})):
     """ABC for objects that can be RLP encoded as is."""
     pass
 


### PR DESCRIPTION
One possible fix for issue #14.

Atomic retains the properties of ABCMeta while being declared in a syntax that is also compatible with Python2!

Since this looks a little ugly it's understandable it not being merged in which case it could be added as a single line diff to be applied by the FreeBSD port (cc @yurivict, @mtgran).
