### PR TITLE
Allow desirealization into a mutable object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ pip-delete-this-directory.txt
 htmlcov/
 .tox/
 .coverage
+.coverage.*
 .cache
 nosetests.xml
 coverage.xml

--- a/rlp/__init__.py
+++ b/rlp/__init__.py
@@ -1,6 +1,20 @@
 from . import sedes
-from .codec import encode, decode, infer_sedes, descend, append, pop, compare_length, insert
-from .exceptions import RLPException, EncodingError, DecodingError,  \
-                        SerializationError, DeserializationError
+from .codec import (
+    encode,
+    decode,
+    infer_sedes,
+    descend,
+    append,
+    pop,
+    compare_length,
+    insert,
+)
+from .exceptions import (
+    RLPException,
+    EncodingError,
+    DecodingError,
+    SerializationError,
+    DeserializationError,
+)
 from .lazy import decode_lazy, peek, LazyList
-from .sedes import Serializable, make_immutable
+from .sedes import Serializable, make_immutable, make_mutable

--- a/rlp/sedes/__init__.py
+++ b/rlp/sedes/__init__.py
@@ -1,4 +1,4 @@
 from . import raw
 from .binary import Binary, binary
 from .big_endian_int import BigEndianInt, big_endian_int
-from .lists import CountableList, List, Serializable, make_immutable
+from .lists import CountableList, List, Serializable, make_immutable, make_mutable

--- a/rlp/sedes/lists.py
+++ b/rlp/sedes/lists.py
@@ -213,7 +213,7 @@ class Serializable(object):
         make_immutable(self)
 
     def make_mutable(self):
-        """Make it mutable to prevent accidental changes.
+        """Make it mutable.
 
         `obj.make_mutable` is equivalent to `make_mutable(obj)`, but doesn't return
         anything.
@@ -302,7 +302,7 @@ def make_mutable(x):
     containing them. If `x` is an instance of :class:`rlp.Serializable`, apply this function to its
     fields, and set :attr:`_mutable` to `False`. If `x` is neither of the above, just return `x`.
 
-    :returns: `x` after making it mmutable
+    :returns: `x` after making it mutable
     """
     if isinstance(x, Serializable):
         x._mutable = True
@@ -314,6 +314,6 @@ def make_mutable(x):
                 pass  # respect read only properties
         return x
     elif is_sequence(x):
-        return tuple(make_mutable(element) for element in x)
+        return list(make_mutable(element) for element in x)
     else:
         return x

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 import pytest
 from rlp import SerializationError
-from rlp import infer_sedes, Serializable, encode, decode, make_immutable
+from rlp import infer_sedes, Serializable, encode, decode, make_immutable, make_mutable
 from rlp.sedes import big_endian_int, binary, List
 
 
@@ -68,11 +68,10 @@ def test_serializable():
     # deserialization
     test1a_d = Test1.deserialize(serial_1a)
     test1b_d = Test1.deserialize(serial_1b)
-    test2_d = Test2.deserialize(serial_2)
-
+    test2_d = Test2.deserialize(serial_2, _mutable=True)
     assert not test1a_d.is_mutable()
     assert not test1b_d.is_mutable()
-    assert not test2_d.is_mutable()
+    assert test2_d.is_mutable()
     for obj in (test1a_d, test1b_d):
         before1 = obj.field1
         before2 = obj.field2
@@ -145,3 +144,51 @@ def test_make_immutable():
     assert not test2.is_mutable()
     assert not test1a.is_mutable()
     assert not test1b.is_mutable()
+
+
+def test_make_mutable():
+    assert make_mutable(1) == 1
+    assert make_mutable('a') == 'a'
+    assert make_mutable((1, 2, 3)) == (1, 2, 3)
+    assert make_mutable([1, 2, 'a']) == (1, 2, 'a')
+    assert make_mutable([[1], [2, [3], 4], 5, 6]) == ((1,), (2, (3,), 4), 5, 6)
+
+    t1a_data = (5, 'a', (0, ''))
+    t1b_data = (9, 'b', (2, ''))
+    test1a = Test1(*t1a_data)
+    test1b = Test1(*t1b_data)
+    test2 = Test2(test1a, [test1a, test1b])
+
+    test1a.make_immutable()
+    test1b.make_immutable()
+    test2.make_immutable()
+
+    assert not test2.is_mutable()
+    assert not test2.field1.is_mutable()
+    assert not test2.field2[0].is_mutable()
+    assert not test2.field2[1].is_mutable()
+    test2.make_mutable()
+    assert test2.is_mutable()
+    assert test2.field2[0].is_mutable()
+    assert test2.field2[1].is_mutable()
+    assert test1a.is_mutable()
+    assert test1b.is_mutable()
+    assert test2.field1 == test1a
+    assert test2.field2 == (test1a, test1b)
+
+    test1a = Test1(*t1a_data)
+    test1b = Test1(*t1b_data)
+    test2 = Test2(test1a, [test1a, test1b])
+
+    test1a.make_immutable()
+    test1b.make_immutable()
+    test2.make_immutable()
+
+    assert not test2.is_mutable()
+    assert not test2.field1.is_mutable()
+    assert not test2.field2[0].is_mutable()
+    assert not test2.field2[1].is_mutable()
+    assert make_mutable([test1a, [test2, test1b]]) == (test1a, (test2, test1b))
+    assert test2.is_mutable()
+    assert test1a.is_mutable()
+    assert test1b.is_mutable()

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -149,9 +149,9 @@ def test_make_immutable():
 def test_make_mutable():
     assert make_mutable(1) == 1
     assert make_mutable('a') == 'a'
-    assert make_mutable((1, 2, 3)) == (1, 2, 3)
-    assert make_mutable([1, 2, 'a']) == (1, 2, 'a')
-    assert make_mutable([[1], [2, [3], 4], 5, 6]) == ((1,), (2, (3,), 4), 5, 6)
+    assert make_mutable((1, 2, 3)) == [1, 2, 3]
+    assert make_mutable([1, 2, 'a']) == [1, 2, 'a']
+    assert make_mutable([[1], [2, [3], 4], 5, 6]) == [[1,], [2, [3,], 4], 5, 6]
 
     t1a_data = (5, 'a', (0, ''))
     t1b_data = (9, 'b', (2, ''))
@@ -174,7 +174,7 @@ def test_make_mutable():
     assert test1a.is_mutable()
     assert test1b.is_mutable()
     assert test2.field1 == test1a
-    assert test2.field2 == (test1a, test1b)
+    assert test2.field2 == [test1a, test1b]
 
     test1a = Test1(*t1a_data)
     test1b = Test1(*t1b_data)
@@ -188,7 +188,7 @@ def test_make_mutable():
     assert not test2.field1.is_mutable()
     assert not test2.field2[0].is_mutable()
     assert not test2.field2[1].is_mutable()
-    assert make_mutable([test1a, [test2, test1b]]) == (test1a, (test2, test1b))
+    assert make_mutable([test1a, [test2, test1b]]) == [test1a, [test2, test1b]]
     assert test2.is_mutable()
     assert test1a.is_mutable()
     assert test1b.is_mutable()

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -68,7 +68,7 @@ def test_serializable():
     # deserialization
     test1a_d = Test1.deserialize(serial_1a)
     test1b_d = Test1.deserialize(serial_1b)
-    test2_d = Test2.deserialize(serial_2, _mutable=True)
+    test2_d = Test2.deserialize(serial_2, mutable=True)
     assert not test1a_d.is_mutable()
     assert not test1b_d.is_mutable()
     assert test2_d.is_mutable()


### PR DESCRIPTION
### What was the problem

All objects returned from either `rlp.decode` or `Serializable.deserialize` are currenty immutable and the `rlp` API has nothing available for making things `mutable`.

### How was it fixed

Implemented the *inverse* of the `make_immutable` API.  There is now both a standalone `make_immutable` function as well as a `make_immutable` class method on the `Serializable` type.

The current behavior of defaulting to immutable objects on deserialization is preserved.

#### Cute animal picture

![giraffe_and_baby_giraffe_1280x960](https://cloud.githubusercontent.com/assets/824194/24621426/a45c0be4-185e-11e7-85f2-95e69632702a.jpeg)
