### PR TITLE
tox: pass TRAVIS* environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
 #  - TOXENV=py34
 #  - TOXENV=py35
 #  - TOXENV=pypy3
+  - TOXENV=coverage
 
 install:
  - pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,9 @@ envlist = py27,pypy,coverage
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/pyrlp
-commands = coverage run --parallel --source=rlp --branch -m py.test {posargs}
+commands =
+    printenv
+    coverage run --parallel --source=rlp --branch -m py.test {posargs}
 deps =
     -r{toxinidir}/requirements.txt
     pytest==2.8.4
@@ -17,5 +19,6 @@ deps =
     coverage==4.0.3
 skip_install = true
 commands =
+    printenv
     coverage combine
     coverage report --show-missing

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@
 envlist = py27,pypy,coverage
 
 [testenv]
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/pyrlp
 commands = coverage run --parallel --source=rlp --branch -m py.test {posargs}


### PR DESCRIPTION
It seems that coveralls.io jobs for all PRs are failing (yellow light).

Github reports "Coverage pending from Coveralls.io", Coveralls.io says "No data available in table" for specific jobs (waiting for Travis report), and Travis reports "Coverage submitted!"

As suggested in `coveralls-python` README:

https://github.com/coveralls-clients/coveralls-python#usage-tox--v20

This PR passes some environment variables to the `testenv`, so that `tox` mentions which job the data is for when submitting to coveralls.

It is my hope that Travis will be able to pick up on the changes in this PR, and use the proposed environment, therefore submitting a report with proper metadata to Coveralls. (AFAIK on some setups, this is explicitly forbidden.)