### PR TITLE
Remove meaningless check in Serializable.serialize

### DIFF
--- a/rlp/sedes/lists.py
+++ b/rlp/sedes/lists.py
@@ -220,8 +220,6 @@ class Serializable(object):
 
     @classmethod
     def serialize(cls, obj):
-        if not hasattr(obj, 'fields'):
-            raise ObjectSerializationError('Cannot serialize this object (no fields)', obj)
         try:
             field_values = [getattr(obj, field) for field, _ in cls.fields]
         except AttributeError:


### PR DESCRIPTION
Replaces #16 (rebased off develop)

`Serializable.serialize` uses the serializable class's own fields (`cls.fields`) to serialize `obj`, not `obj`'s fields, the check is checking unrelated things.
