### PR TITLE
Fix for decode_hex() not working correctly in Python3

### DIFF
--- a/rlp/utils_py3.py
+++ b/rlp/utils_py3.py
@@ -46,7 +46,7 @@ def is_integer(value):
 def decode_hex(s):
     if isinstance(s, str):
         return bytes.fromhex(s)
-    if isinstance(b, (bytes, bytearray)):
+    if isinstance(s, (bytes, bytearray)):
         return binascii.unhexlify(s)
     raise TypeError('Value must be an instance of str or bytes')
 


### PR DESCRIPTION
the method used to reference an undefined variable 'b'