### PR TITLE
Treat bytearray as bytes in Python 3, same as in Python 2

### DIFF
--- a/rlp/sedes/binary.py
+++ b/rlp/sedes/binary.py
@@ -27,7 +27,7 @@ class Binary(object):
         if sys.version_info.major == 2:
             return isinstance(obj, (str, unicode, bytearray))
         else:
-            return isinstance(obj, (str, bytes))
+            return isinstance(obj, (str, bytes, bytearray))
 
     def is_valid_length(self, l):
         return any((self.min_length <= l <= self.max_length,

--- a/rlp/utils_py3.py
+++ b/rlp/utils_py3.py
@@ -10,6 +10,7 @@ class Atomic(type.__new__(abc.ABCMeta, 'metaclass', (), {})):
 
 Atomic.register(str)
 Atomic.register(bytes)
+Atomic.register(bytearray)
 
 
 def str_to_bytes(value):

--- a/tests/test_bytearray.py
+++ b/tests/test_bytearray.py
@@ -33,3 +33,11 @@ def test_big_endian_to_int():
     value = struct.pack('>Q', 3141516)
     assert rlp.utils.big_endian_to_int(value) == 3141516
     assert rlp.utils.big_endian_to_int(bytearray(value)) == 3141516
+
+
+def test_encoding_bytearray():
+    s = rlp.utils.str_to_bytes('abcdef')
+    direct = rlp.encode(s)
+    from_bytearray = rlp.encode(bytearray(s))
+    assert direct == from_bytearray
+    assert rlp.decode(direct) == s


### PR DESCRIPTION
This seems to be the right thing to do. In python2, bytearray is treated as a string. In python3, the code kinda-sorta-explicitly excludes bytearray, but that results in bytearray being treated as a list. Hence, encoding `bytearray('hello')` in python 2 decodes to `'hello'` but doing the same in python 3 decodes to `[b'h', b'e', b'l', b'l', b'o']`.

This PR unifies the behavior, in a direction that I think makes more sense.