### PR TITLE
Piper/use eth utils big endian tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,8 @@ matrix:
       env: TOX_POSARGS="-e py35"
     - python: "3.6"
       env: TOX_POSARGS="-e py36"
-    # TODO: https://github.com/pytoolz/cytoolz/issues/118
-    #- python: "pypy3"
-    #- env: TOX_POSARGS="-e pypy3"
+    - python: "pypy3.5"
+      env: TOX_POSARGS="-e pypy3"
     - python: "3.6"
       env: TOX_POSARGS="-e lint"
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ matrix:
       env: TOX_POSARGS="-e py35"
     - python: "3.6"
       env: TOX_POSARGS="-e py36"
-    - python: "pypy3"
-      env: TOX_POSARGS="-e pypy3"
+    # TODO: https://github.com/pytoolz/cytoolz/issues/118
+    #- python: "pypy3"
+    #- env: TOX_POSARGS="-e pypy3"
     - python: "3.6"
       env: TOX_POSARGS="-e lint"
 cache:

--- a/rlp/codec.py
+++ b/rlp/codec.py
@@ -1,13 +1,16 @@
 import collections
 
+from eth_utils import (
+    int_to_big_endian,
+    big_endian_to_int,
+)
+
 from rlp.exceptions import EncodingError, DecodingError
 from rlp.utils import (
     Atomic,
     ascii_chr,
-    big_endian_to_int,
     decode_hex,
     encode_hex,
-    int_to_big_endian,
     is_integer,
     safe_ord,
     str_to_bytes,

--- a/rlp/sedes/big_endian_int.py
+++ b/rlp/sedes/big_endian_int.py
@@ -1,5 +1,10 @@
+from eth_utils import (
+    int_to_big_endian,
+    big_endian_to_int,
+)
+
 from rlp.exceptions import DeserializationError, SerializationError
-from rlp.utils import int_to_big_endian, big_endian_to_int, is_integer, ascii_chr
+from rlp.utils import is_integer, ascii_chr
 
 
 class BigEndianInt(object):

--- a/rlp/utils.py
+++ b/rlp/utils.py
@@ -1,6 +1,5 @@
 import abc
 import binascii
-from math import ceil
 
 
 class Atomic(type.__new__(abc.ABCMeta, 'metaclass', (), {})):
@@ -29,15 +28,6 @@ def bytes_to_str(value):
 
 def ascii_chr(value):
     return bytes([value])
-
-
-def int_to_big_endian(value):
-    byte_length = max(ceil(value.bit_length() / 8), 1)
-    return (value).to_bytes(byte_length, byteorder='big')
-
-
-def big_endian_to_int(value):
-    return int.from_bytes(value, byteorder='big')
 
 
 def is_integer(value):

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,9 @@ setup(
     packages=find_packages(exclude=["tests", "tests.*"]),
     include_package_data=True,
     setup_requires=['setuptools-markdown'],
-    install_requires=[],
+    install_requires=[
+        "eth-utils>=1.0.2,<2",
+    ],
     extras_require=extras_require,
     license="MIT",
     zip_safe=False,

--- a/tests/test_big_endian.py
+++ b/tests/test_big_endian.py
@@ -2,9 +2,11 @@ import binascii
 
 import pytest
 
+from eth_utils import int_to_big_endian
+
 from rlp import SerializationError, utils
 from rlp.sedes import big_endian_int, BigEndianInt
-from rlp.utils import int_to_big_endian
+
 
 valid_data = (
     (256, b'\x01\x00'),

--- a/tests/test_binary_sedes.py
+++ b/tests/test_binary_sedes.py
@@ -1,6 +1,4 @@
 # -*- coding: UTF-8 -*-
-from __future__ import unicode_literals
-
 import pytest
 from rlp import SerializationError, utils
 from rlp.sedes import Binary

--- a/tests/test_bytearray.py
+++ b/tests/test_bytearray.py
@@ -1,9 +1,4 @@
 # -*- coding: utf8 -*-
-from eth_utils import (
-    encode_hex,
-    decode_hex,
-)
-
 from rlp import (
     encode,
     decode,
@@ -24,14 +19,6 @@ def test_bytearray_lazy():
     expected = decode(e)
     actual = decode_lazy(bytearray(e))
     assert expected == actual
-
-
-def test_bytearray_encode_decode():
-    value = bytearray(b'asdf')
-    encoded = encode_hex(value)
-    decoded = decode_hex(encoded)
-
-    assert value == decoded
 
 
 def test_encoding_bytearray():

--- a/tests/test_bytearray.py
+++ b/tests/test_bytearray.py
@@ -1,43 +1,42 @@
 # -*- coding: utf8 -*-
-import struct
+from eth_utils import (
+    encode_hex,
+    decode_hex,
+)
 
-import rlp
+from rlp import (
+    encode,
+    decode,
+    decode_lazy,
+)
+from rlp.utils import str_to_bytes
 
 
 def test_bytearray():
-    e = rlp.encode('abc')
-    expected = rlp.decode(e)
-    actual = rlp.decode(bytearray(e))
-    assert expected == actual
+    e = encode('abc')
+    expected = decode(e)
+    actual = decode(bytearray(e))
+    assert actual == expected
 
 
 def test_bytearray_lazy():
-    e = rlp.encode('abc')
-    expected = rlp.decode(e)
-    actual = rlp.decode_lazy(bytearray(e))
+    e = encode('abc')
+    expected = decode(e)
+    actual = decode_lazy(bytearray(e))
     assert expected == actual
 
 
 def test_bytearray_encode_decode():
     value = bytearray(b'asdf')
-    encoded = rlp.utils.encode_hex(value)
-    decoded = rlp.utils.decode_hex(encoded)
+    encoded = encode_hex(value)
+    decoded = decode_hex(encoded)
 
     assert value == decoded
 
 
-def test_big_endian_to_int():
-    assert rlp.utils.big_endian_to_int(b'\x00') == 0
-    assert rlp.utils.big_endian_to_int(bytearray(b'\x00')) == 0
-
-    value = struct.pack('>Q', 3141516)
-    assert rlp.utils.big_endian_to_int(value) == 3141516
-    assert rlp.utils.big_endian_to_int(bytearray(value)) == 3141516
-
-
 def test_encoding_bytearray():
-    s = rlp.utils.str_to_bytes('abcdef')
-    direct = rlp.encode(s)
-    from_bytearray = rlp.encode(bytearray(s))
+    s = str_to_bytes('abcdef')
+    direct = encode(s)
+    from_bytearray = encode(bytearray(s))
     assert direct == from_bytearray
-    assert rlp.decode(direct) == s
+    assert decode(direct) == s

--- a/tests/test_countablelist.py
+++ b/tests/test_countablelist.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 import rlp
 from rlp.sedes import big_endian_int

--- a/tests/test_invalid.py
+++ b/tests/test_invalid.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 from rlp import decode, DecodingError
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -34,11 +34,12 @@ def compare_nested(got, expected):
             return False
 
 
-with open('tests/rlptest.json') as f:
-    test_data = json.loads(f.read())
-    test_pieces = [(name, {'in': to_bytes(in_out['in']),
-                           'out': in_out['out']})
-                   for name, in_out in test_data.items()]
+with open('tests/rlptest.json') as rlptest_file:
+    test_data = json.load(rlptest_file)
+    test_pieces = [
+        (name, {'in': to_bytes(in_out['in']), 'out': in_out['out']})
+        for name, in_out in test_data.items()
+    ]
 
 
 @pytest.mark.parametrize('name, in_out', test_pieces)

--- a/tests/test_raw_sedes.py
+++ b/tests/test_raw_sedes.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 from rlp import encode, decode, SerializationError
 from rlp.sedes import raw


### PR DESCRIPTION
Builds on: https://github.com/ethereum/pyrlp/pull/53

### What was wrong

We have a library `eth-utils` that contains many of the utils that are implemented in this module.


### How was it fixed

Changed to use `int_to_big_endian` and `big_endian_to_int` utils from `eth-utils` library.