### PR TITLE
Library cleanup: Drop un-used APIs, optimizations, cleanup

### DIFF
--- a/rlp/__init__.py
+++ b/rlp/__init__.py
@@ -3,11 +3,6 @@ from .codec import (  # noqa: F401
     encode,
     decode,
     infer_sedes,
-    descend,
-    append,
-    pop,
-    compare_length,
-    insert,
 )
 from .exceptions import (  # noqa: F401
     RLPException,

--- a/rlp/lazy.py
+++ b/rlp/lazy.py
@@ -54,10 +54,10 @@ def consume_item_lazy(rlp, start):
               unprocessed byte.
     """
     t, l, s = consume_length_prefix(rlp, start)
-    if t == str:
-        return consume_payload(rlp, s, str, l)
+    if t is bytes:
+        return consume_payload(rlp, s, bytes, l)
     else:
-        assert t == list
+        assert t is list
         return LazyList(rlp, s, s + l), s + l
 
 

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -5,11 +5,31 @@ from eth_utils import (
 )
 
 from rlp.exceptions import DecodingError
+from rlp.codec import consume_length_prefix
 from rlp import (
     decode,
     encode,
-    compare_length,
 )
+
+
+EMPTYLIST = encode([])
+
+
+def compare_length(rlpdata, length):
+    _typ, _len, _pos = consume_length_prefix(rlpdata, 0)
+    assert _typ is list
+    lenlist = 0
+    if rlpdata == EMPTYLIST:
+        return -1 if length > 0 else 1 if length < 0 else 0
+    while 1:
+        if lenlist > length:
+            return 1
+        _, _l, _p = consume_length_prefix(rlpdata, _pos)
+        lenlist += 1
+        if _l + _p >= len(rlpdata):
+            break
+        _pos = _l + _p
+    return 0 if lenlist == length else -1
 
 
 def test_compare_length():


### PR DESCRIPTION
### What was wrong

Low hanging fruit that was asking to be cleaned up.

### How was it fixed.

- Some simple optimizations like setting module level constants.
- Use of `to_tuple` and `to_list` in favor of accumulation pattern.
- Removal of multiple APIs that are not used and not tested. `pop`, `insert`, `append`, `descend`, `compare_length`
- More conversions to only accept `bytes` types instead of `str`