### PR TITLE
Piper/remove mutable kwargs from serializable intitialization

### DIFF
--- a/rlp/codec.py
+++ b/rlp/codec.py
@@ -31,8 +31,7 @@ def encode(obj, sedes=None, infer_serializer=True, cache=True):
     replaced by specifying `sedes`).
 
     If `obj` is a :class:`rlp.Serializable` and `cache` is true, the result of
-    the encoding will be stored in :attr:`_cached_rlp` if it is empty and
-    :meth:`rlp.Serializable.make_immutable` will be invoked on `obj`.
+    the encoding will be stored in :attr:`_cached_rlp` if it is empty.
 
     :param sedes: an object implementing a function ``serialize(obj)`` which will be used to
                   serialize ``obj`` before encoding, or ``None`` to use the infered one (if any)

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -21,6 +21,17 @@ class RLPType2(Serializable):
     ]
 
 
+class RLPType3(Serializable):
+    fields = [
+        ('field1', big_endian_int),
+        ('field2', big_endian_int),
+        ('field3', big_endian_int),
+    ]
+
+    def __init__(self, field2, field1, field3, **kwargs):
+        super().__init__(field1=field1, field2=field2, field3=field3, **kwargs)
+
+
 _type_1_a = RLPType1(5, b'a', (0, b''))
 _type_1_b = RLPType1(9, b'b', (2, b''))
 _type_2 = RLPType2(_type_1_a, [_type_1_a, _type_1_b])
@@ -88,15 +99,32 @@ def test_serializable_initialization_validation(rlptype, args, kwargs, exception
             rlptype(*args, **kwargs)
 
 
-class RLPType3(Serializable):
-    fields = [
-        ('field1', big_endian_int),
-        ('field2', big_endian_int),
-        ('field3', big_endian_int),
-    ]
+@pytest.mark.parametrize(
+    'args,kwargs',
+    (
+        ([2, 1, 3], {}),
+        ([2, 1], {'field3': 3}),
+        ([2], {'field3': 3, 'field1': 1}),
+        ([], {'field3': 3, 'field1': 1, 'field2': 2}),
+    ),
+)
+def test_serializable_initialization_args_kwargs_mix(args, kwargs):
+    obj = RLPType3(*args, **kwargs)
+    assert obj.field1 == 1
+    assert obj.field2 == 2
+    assert obj.field3 == 3
 
-    def __init__(self, field2, field1, field3, **kwargs):
-        super().__init__(field1=field1, field2=field2, field3=field3, **kwargs)
+
+def test_serializable_create_mutable():
+    obj = RLPType3.create_mutable(1, 2, 3)
+    assert obj.is_mutable
+    assert not obj.is_immutable
+
+
+def test_serializable_create_immutable():
+    obj = RLPType3.create_immutable(1, 2, 3)
+    assert obj.is_immutable
+    assert not obj.is_mutable
 
 
 def test_deserialization_for_custom_init_method():

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -88,6 +88,30 @@ def test_serializable_initialization_validation(rlptype, args, kwargs, exception
             rlptype(*args, **kwargs)
 
 
+class RLPType3(Serializable):
+    fields = [
+        ('field1', big_endian_int),
+        ('field2', big_endian_int),
+        ('field3', big_endian_int),
+    ]
+
+    def __init__(self, field2, field1, field3, **kwargs):
+        super().__init__(field1=field1, field2=field2, field3=field3, **kwargs)
+
+
+def test_deserialization_for_custom_init_method():
+    type_3 = RLPType3(2, 1, 3)
+    assert type_3.field1 == 1
+    assert type_3.field2 == 2
+    assert type_3.field3 == 3
+
+    result = decode(encode(type_3), sedes=RLPType3)
+
+    assert result.field1 == 1
+    assert result.field2 == 2
+    assert result.field3 == 3
+
+
 def test_serializable_iterator():
     values = (5, b'a', (1, b'c'))
     obj = RLPType1(*values)


### PR DESCRIPTION
Builds on https://github.com/ethereum/pyrlp/pull/69

### What was wrong

The `mutable` argument in `Serializable.__init__` made subclassing awkward as it required all subclasses to include either the `mutable` argument in the `__init__` or to pass down `**kwargs``.

### How was it fixed

Removed the arg from `__init__` in favor of two new `classmethod`s.

- `Serializable.create_mutable`
- `Serializable.create_immutable`