### PR TITLE
Piper/fix inheritance for serializables

### DIFF
--- a/rlp/codec.py
+++ b/rlp/codec.py
@@ -31,8 +31,7 @@ def encode(obj, sedes=None, infer_serializer=True, cache=True):
     replaced by specifying `sedes`).
 
     If `obj` is a :class:`rlp.Serializable` and `cache` is true, the result of
-    the encoding will be stored in :attr:`_cached_rlp` if it is empty and
-    :meth:`rlp.Serializable.make_immutable` will be invoked on `obj`.
+    the encoding will be stored in :attr:`_cached_rlp` if it is empty.
 
     :param sedes: an object implementing a function ``serialize(obj)`` which will be used to
                   serialize ``obj`` before encoding, or ``None`` to use the infered one (if any)

--- a/rlp/sedes/serializable.py
+++ b/rlp/sedes/serializable.py
@@ -233,14 +233,13 @@ class SerializableBase(abc.ABCMeta):
         # Ensure initialization is only performed for subclasses of SerializableBase
         # (excluding Model class itself).
         is_serializable_subclass = any(b for b in bases if isinstance(b, SerializableBase))
-        if not is_serializable_subclass:
+        declares_fields = 'fields' in attrs
+
+        if not is_serializable_subclass or not declares_fields:
             return super_new(cls, name, bases, attrs)
 
-        fields = attrs.pop('fields', tuple())
-        if fields:
-            field_names, sedes = zip(*fields)
-        else:
-            field_names, sedes = tuple(), tuple()
+        fields = attrs.pop('fields')
+        field_names, sedes = zip(*fields)
 
         field_attrs = _mk_field_attrs(field_names, attrs.keys())
 
@@ -262,7 +261,7 @@ class SerializableBase(abc.ABCMeta):
         field_props = {
             field: _mk_field_property(field, attr)
             for field, attr
-            in zip(field_names, field_attrs)
+            in zip(meta.field_names, meta.field_attrs)
         }
 
         return super_new(

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -21,6 +21,17 @@ class RLPType2(Serializable):
     ]
 
 
+class RLPType3(Serializable):
+    fields = [
+        ('field1', big_endian_int),
+        ('field2', big_endian_int),
+        ('field3', big_endian_int),
+    ]
+
+    def __init__(self, field2, field1, field3, **kwargs):
+        super().__init__(field1=field1, field2=field2, field3=field3, **kwargs)
+
+
 _type_1_a = RLPType1(5, b'a', (0, b''))
 _type_1_b = RLPType1(9, b'b', (2, b''))
 _type_2 = RLPType2(_type_1_a, [_type_1_a, _type_1_b])
@@ -88,15 +99,32 @@ def test_serializable_initialization_validation(rlptype, args, kwargs, exception
             rlptype(*args, **kwargs)
 
 
-class RLPType3(Serializable):
-    fields = [
-        ('field1', big_endian_int),
-        ('field2', big_endian_int),
-        ('field3', big_endian_int),
-    ]
+@pytest.mark.parametrize(
+    'args,kwargs',
+    (
+        ([2, 1, 3], {}),
+        ([2, 1], {'field3': 3}),
+        ([2], {'field3': 3, 'field1': 1}),
+        ([], {'field3': 3, 'field1': 1, 'field2': 2}),
+    ),
+)
+def test_serializable_initialization_args_kwargs_mix(args, kwargs):
+    obj = RLPType3(*args, **kwargs)
+    assert obj.field1 == 1
+    assert obj.field2 == 2
+    assert obj.field3 == 3
 
-    def __init__(self, field2, field1, field3, **kwargs):
-        super().__init__(field1=field1, field2=field2, field3=field3, **kwargs)
+
+def test_serializable_create_mutable():
+    obj = RLPType3.create_mutable(1, 2, 3)
+    assert obj.is_mutable
+    assert not obj.is_immutable
+
+
+def test_serializable_create_immutable():
+    obj = RLPType3.create_immutable(1, 2, 3)
+    assert obj.is_immutable
+    assert not obj.is_mutable
 
 
 def test_deserialization_for_custom_init_method():

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -88,6 +88,30 @@ def test_serializable_initialization_validation(rlptype, args, kwargs, exception
             rlptype(*args, **kwargs)
 
 
+class RLPType3(Serializable):
+    fields = [
+        ('field1', big_endian_int),
+        ('field2', big_endian_int),
+        ('field3', big_endian_int),
+    ]
+
+    def __init__(self, field2, field1, field3, **kwargs):
+        super().__init__(field1=field1, field2=field2, field3=field3, **kwargs)
+
+
+def test_deserialization_for_custom_init_method():
+    type_3 = RLPType3(2, 1, 3)
+    assert type_3.field1 == 1
+    assert type_3.field2 == 2
+    assert type_3.field3 == 3
+
+    result = decode(encode(type_3), sedes=RLPType3)
+
+    assert result.field1 == 1
+    assert result.field2 == 2
+    assert result.field3 == 3
+
+
 def test_serializable_iterator():
     values = (5, b'a', (1, b'c'))
     obj = RLPType1(*values)

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -32,6 +32,10 @@ class RLPType3(Serializable):
         super().__init__(field1=field1, field2=field2, field3=field3, **kwargs)
 
 
+class RLPType4(RLPType3):
+    pass
+
+
 _type_1_a = RLPType1(5, b'a', (0, b''))
 _type_1_b = RLPType1(9, b'b', (2, b''))
 _type_2 = RLPType2(_type_1_a, [_type_1_a, _type_1_b])
@@ -110,6 +114,13 @@ def test_serializable_initialization_validation(rlptype, args, kwargs, exception
 )
 def test_serializable_initialization_args_kwargs_mix(args, kwargs):
     obj = RLPType3(*args, **kwargs)
+    assert obj.field1 == 1
+    assert obj.field2 == 2
+    assert obj.field3 == 3
+
+
+def test_serializable_subclass_retains_field_info_from_parent():
+    obj = RLPType4(2, 1, 3)
     assert obj.field1 == 1
     assert obj.field2 == 2
     assert obj.field3 == 3


### PR DESCRIPTION
builds on https://github.com/ethereum/pyrlp/pull/69

### What was wrong

Simple inheritance of `Serializable` classes resulted in full loss of field information.  This was due to how the metaclass defaulted to assuming no fields were declared and thus defaulting the field set to be empty.

### How was it fixed

Only create and override the `_meta` value if `fields` was declared.