### PR TITLE
rlp.Serializables are now strictly immutable

### DIFF
--- a/rlp/__init__.py
+++ b/rlp/__init__.py
@@ -12,4 +12,4 @@ from .exceptions import (  # noqa: F401
     DeserializationError,
 )
 from .lazy import decode_lazy, peek, LazyList  # noqa: F401
-from .sedes import Serializable, make_immutable, make_mutable  # noqa: F401
+from .sedes import Serializable  # noqa: F401

--- a/rlp/sedes/__init__.py
+++ b/rlp/sedes/__init__.py
@@ -2,4 +2,4 @@ from . import raw  # noqa: F401
 from .binary import Binary, binary  # noqa: F401
 from .big_endian_int import BigEndianInt, big_endian_int  # noqa: F401
 from .lists import CountableList, List  # noqa: F401
-from .serializable import Serializable, make_immutable, make_mutable  # noqa: F401
+from .serializable import Serializable  # noqa: F401


### PR DESCRIPTION
### What was wrong

RLP objects *might* be mutable or maybe not...  uncertainty in this department leads to requiring checks in code prior to mutation, or to **always** make a mutable copy when mutating.  This is an awkward API.

Also, mutable objects are harder to reason about.  This has shown itself in the Py-EVM codebase where things like block headers were getting *implicitely* updated.

### How was it fixed

This is the first step in the fix, removing all of the APIs around mutability and defaulting all `Serializable` instances to being immutable.

Next step is going to be adding new APIs for making copies of rlp objects with fields overridden.

![camel1](https://user-images.githubusercontent.com/824194/39070192-98935268-449f-11e8-9786-7d2b875f794c.jpg)
