### PR TITLE
Piper/apis for making copies of rlp serializables

### DIFF
--- a/rlp/__init__.py
+++ b/rlp/__init__.py
@@ -12,4 +12,4 @@ from .exceptions import (  # noqa: F401
     DeserializationError,
 )
 from .lazy import decode_lazy, peek, LazyList  # noqa: F401
-from .sedes import Serializable, make_immutable, make_mutable  # noqa: F401
+from .sedes import Serializable  # noqa: F401

--- a/rlp/sedes/__init__.py
+++ b/rlp/sedes/__init__.py
@@ -2,4 +2,4 @@ from . import raw  # noqa: F401
 from .binary import Binary, binary  # noqa: F401
 from .big_endian_int import BigEndianInt, big_endian_int  # noqa: F401
 from .lists import CountableList, List  # noqa: F401
-from .serializable import Serializable, make_immutable, make_mutable  # noqa: F401
+from .serializable import Serializable  # noqa: F401

--- a/rlp/sedes/serializable.py
+++ b/rlp/sedes/serializable.py
@@ -188,7 +188,7 @@ class BaseSerializable(collections.Sequence):
             yield c_self
         except Exception:
             for value, attr in zip(c_values, self._meta.field_attrs):
-                setattr(c_self, attr, value)
+                setattr(c_self, attr, make_immutable(value))
             raise
         finally:
             c_self._in_mutable_context = False

--- a/rlp/sedes/serializable.py
+++ b/rlp/sedes/serializable.py
@@ -115,7 +115,7 @@ class BaseSerializable(collections.Sequence):
             attr = self._meta.field_attrs[idx]
             return getattr(self, attr)
         elif isinstance(idx, slice):
-            field_slice = self._meta.field_Gttrs[idx]
+            field_slice = self._meta.field_attrs[idx]
             return tuple(getattr(self, field) for field in field_slice)
         elif isinstance(idx, str):
             return getattr(self, idx)

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -105,6 +105,17 @@ def test_serializable_initialization_args_kwargs_mix(args, kwargs):
     assert obj.field3 == 3
 
 
+@pytest.mark.parametrize(
+    'lookup,expected',
+    (
+        (0, 5),
+    ),
+)
+def test_serializable_getitem_lookups(type_1_a, lookup, expected):
+    actual = type_1_a[lookup]
+    assert actual == expected
+
+
 def test_serializable_subclass_retains_field_info_from_parent():
     obj = RLPType4(2, 1, 3)
     assert obj.field1 == 1

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -278,3 +278,122 @@ def test_serializable_inheritance():
         c3.field1
     with pytest.raises(AttributeError):
         c3.field3
+
+
+def test_serializable_basic_copy(type_1_a):
+    n_type_1_a = type_1_a.copy()
+    assert n_type_1_a == type_1_a
+    assert n_type_1_a is not type_1_a
+
+
+def test_serializable_copy_with_nested_serializables(type_2):
+    n_type_2 = type_2.copy()
+    assert n_type_2 == type_2
+    assert n_type_2 is not type_2
+
+    assert n_type_2.field2_1 == type_2.field2_1
+    assert n_type_2.field2_1 is not type_2.field2_1
+
+    assert n_type_2.field2_2 == type_2.field2_2
+    assert all(left == right for left, right in zip(n_type_2.field2_2, type_2.field2_2))
+    assert all(left is not right for left, right in zip(n_type_2.field2_2, type_2.field2_2))
+
+
+def test_serializable_build_copy(type_1_a):
+    with type_1_a.build_copy() as c_type_1_a:
+        # ensure that the base object remains immutable
+        with pytest.raises(AttributeError):
+            type_1_a.field1 = 12345
+        assert type_1_a.field1 == 5
+
+        # make changes to copy
+        c_type_1_a.field1 = 1234
+        c_type_1_a.field2 = b'arst'
+
+        # check that the copy has the new field values
+        assert c_type_1_a.field1 == 1234
+        assert c_type_1_a.field2 == b'arst'
+
+        # ensure the base object hasn't changed.
+        assert type_1_a.field1 == 5
+        assert type_1_a.field2 == b'a'
+
+    # check that the copy has the new field values
+    assert c_type_1_a.field1 == 1234
+    assert c_type_1_a.field2 == b'arst'
+
+    # ensure the base object hasn't changed.
+    assert type_1_a.field1 == 5
+    assert type_1_a.field2 == b'a'
+
+    # ensure that we still can't update the base obj
+    with pytest.raises(AttributeError):
+        type_1_a.field1 = 12345
+    assert type_1_a.field1 == 5
+
+    # ensure that we also can't update the copied one
+    with pytest.raises(AttributeError):
+        c_type_1_a.field1 = 12345
+    assert c_type_1_a.field1 == 1234
+
+
+def test_serializable_build_copy_with_params(type_1_a):
+    with type_1_a.build_copy(1234) as c_type_1_a:
+        assert c_type_1_a.field1 == 1234
+
+    assert c_type_1_a.field1 == 1234
+
+
+def test_serializable_build_copy_revert_on_error(type_1_a):
+    try:
+        with type_1_a.build_copy() as c_type_1_a:
+            # make changes to copy
+            c_type_1_a.field1 = 1234
+            c_type_1_a.field2 = b'arst'
+
+            # see that the changes are present
+            assert c_type_1_a.field1 == 1234
+            assert c_type_1_a.field2 == b'arst'
+
+            raise Exception('trigger revert')
+    except Exception:
+        pass
+
+    # ensure the base object hasn't changed.
+    assert type_1_a.field1 == 5
+    assert type_1_a.field2 == b'a'
+
+    # ensure the copy was reverted.
+    assert c_type_1_a.field1 == 5
+    assert c_type_1_a.field2 == b'a'
+
+
+def test_serializable_build_copy_revert_on_error_with_params(type_1_a):
+    with pytest.raises(Exception):
+        with type_1_a.build_copy(1234) as c_type_1_a:
+            # make changes to copy
+            c_type_1_a.field2 = b'arst'
+
+            # see that the changes are present
+            assert c_type_1_a.field1 == 1234
+            assert c_type_1_a.field2 == b'arst'
+
+            raise Exception('trigger revert')
+
+    # ensure the base object hasn't changed.
+    assert type_1_a.field1 == 5
+    assert type_1_a.field2 == b'a'
+
+    # ensure the copy was reverted.
+    assert c_type_1_a.field2 == b'a'
+    # ensure that the override fromt he `build_copy` was persisted.
+    assert c_type_1_a.field1 == 1234
+
+
+def test_serializable_build_copy_cannot_reenter_context(type_1_a):
+    with type_1_a.build_copy() as c_type_1_a:
+        pass
+
+    with pytest.raises(AttributeError):
+        with c_type_1_a:
+            pass


### PR DESCRIPTION
Builds on https://github.com/ethereum/pyrlp/pull/76

### What was wrong

With `rlp.Serializable` objects becoming strictly immutable in https://github.com/ethereum/pyrlp/pull/76 we need a way to build new objects from old ones with overridden fields.

### How was it fixed

Two new APS.

First, `obj.copy(*args, **kwargs)` will return a copy of the object with fields overridden with the provided `args` and `kwargs` values.  Any values not specified are copied from the existing object.

Second, `obj.build_copy(*args, **kwargs)` which is used as a context manager.

```python
with obj.build_copy(field1=3) as obj_copy:
    assert obj_copy.field1 == 3  # args and kwargs from build_copy are immediately set.
    obj_copy.field2 = b'arst'  # fields are mutable within the context.

    # obj.field2 = b'arst'  # parent object remains immutable.  This would throw an AttributeError

assert obj_copy.field1 == 3
assert obj_copy.field2 == b'arst'

# obj_copy.field1 = 4  # object is immutable once it leaves the context.
```

If an error occurs within the context, all changes made within the context are reverted.  Any parameters that were specified in the call to `build_copy` will remain.

#### Cute animal picture

![camel-e1439162067917](https://user-images.githubusercontent.com/824194/39072450-c84c9516-44a7-11e8-9502-b40013405f5c.jpg)
