### PR TITLE
add build_rlp() API to changesets

### DIFF
--- a/rlp/sedes/serializable.py
+++ b/rlp/sedes/serializable.py
@@ -121,6 +121,11 @@ class BaseChangeset:
         self.__diff__ = changes or {}
 
     def commit(self):
+        obj = self.build_rlp()
+        self.close()
+        return obj
+
+    def build_rlp(self):
         if self.__state__ == ChangesetState.OPEN:
             field_kwargs = {
                 name: self.__diff__.get(name, self.__original__[name])
@@ -151,7 +156,8 @@ class BaseChangeset:
             raise ValueError("Cannot open Changeset which is not in the INITIALIZED state")
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.close()
+        if self.__state__ == ChangesetState.OPEN:
+            self.close()
 
 
 def Changeset(obj, changes):

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -385,7 +385,7 @@ def test_serializable_build_changeset_using_open_close_api(type_1_a):
     assert changeset.field1 == 1234
     assert changeset.field2 == b'arst'
 
-    n_type_1_a = changeset.commit()
+    n_type_1_a = changeset.build_rlp()
 
     # check that the copy has the new field values
     assert n_type_1_a.field1 == 1234


### PR DESCRIPTION
### What was wrong

The `changeset.commit()` was written such that you could commit multiple times.  This wasn't intuitive.

### How was it fixed.

Added a new api to the changeset, `build_rlp()` which returns a new object built from the changeset.  The `commit` method has been updated to both close the changeset and return the built rlp object.

![miniature-camel](https://user-images.githubusercontent.com/824194/39205754-d683d3c4-47b8-11e8-8f9f-f047be475642.png)
