### PR TITLE
need to invalidate parent attributes when subclassing

### DIFF
--- a/rlp/sedes/serializable.py
+++ b/rlp/sedes/serializable.py
@@ -368,7 +368,7 @@ class SerializableBase(abc.ABCMeta):
 
         removed_parent_field_props = {
             field_name: RemovedParentField(field_name)
-            for base in bases if issubclass(base, Serializable) if hasattr(base, '_meta')
+            for base in bases if (issubclass(base, Serializable) and hasattr(base, '_meta'))
             for field_name in base._meta.field_names if field_names not in field_props
         }
 

--- a/rlp/sedes/serializable.py
+++ b/rlp/sedes/serializable.py
@@ -379,8 +379,7 @@ class SerializableBase(abc.ABCMeta):
             dict(
                 tuple(field_props.items()) +
                 tuple(removed_parent_field_props.items()) +
-                tuple(attrs.items()) +
-                (('__slots__', meta.field_attrs),)
+                tuple(attrs.items())
             ),
         )
 

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -267,6 +267,7 @@ def test_serializable_inheritance():
     class Child2(Parent):
         fields = (
             ('field1', big_endian_int),
+            ('field2', big_endian_int),
         )
 
     class Child3(Parent):
@@ -404,16 +405,18 @@ def test_serializable_build_changeset_using_open_close_api(type_1_a):
         assert changeset.field1 == 1234
 
 
-def test_serializable_inheritance_excludes_parent_fields():
-    # Make sure that when a Serializable is subclassed and it's fields are
-    # overwritten, that the parent fields are fully removed.
+def test_serializable_inheritance_enforces_inclusion_of_parent_fields():
     class Parent(Serializable):
-        fields = (('field_a', big_endian_int),)
+        fields = (
+            ('field_a', big_endian_int),
+            ('field_b', big_endian_int),
+            ('field_c', big_endian_int),
+            ('field_d', big_endian_int),
+        )
 
-    class Child(Parent):
-        fields = (('field_b', big_endian_int),)
-
-    child = Child(12345)
-
-    with pytest.raises(AttributeError, match="'Child' object has no attribute 'field_a'"):
-        child.field_a
+    with pytest.raises(TypeError, match="field_a,field_c"):
+        class Child(Parent):
+            fields = (
+                ('field_b', big_endian_int),
+                ('field_d', big_endian_int),
+            )

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -402,3 +402,18 @@ def test_serializable_build_changeset_using_open_close_api(type_1_a):
 
     with pytest.raises(AttributeError):
         assert changeset.field1 == 1234
+
+
+def test_serializable_inheritance_excludes_parent_fields():
+    # Make sure that when a Serializable is subclassed and it's fields are
+    # overwritten, that the parent fields are fully removed.
+    class Parent(Serializable):
+        fields = (('field_a', big_endian_int),)
+
+    class Child(Parent):
+        fields = (('field_b', big_endian_int),)
+
+    child = Child(12345)
+
+    with pytest.raises(AttributeError, match="'Child' object has no attribute 'field_a'"):
+        child.field_a


### PR DESCRIPTION
### What was wrong.

When subclassing a `Serializable`, the parent field properties are inherited to the child.  The manner in which these `property` attributes are created still causes them to raise an `AttributeError` when accessed, but it would be better to handle this explicitely.

### How was it fixed

During class creation, all parent fields which are not present on the child class are overridden with a special descriptor which raises the standard `AttributeError` that python raises on objects when trying to access a non-existent attribute.

### Cute animal picture

![5757582223_5fd3839e8f_z](https://user-images.githubusercontent.com/824194/39213899-0694c44e-47d0-11e8-9473-02c869986c60.jpg)
