### PR TITLE
Fix direct subclassing of Serializable without declaring fields

### DIFF
--- a/rlp/sedes/serializable.py
+++ b/rlp/sedes/serializable.py
@@ -368,7 +368,13 @@ class SerializableBase(abc.ABCMeta):
             else:
                 # This is just a vanilla subclass of a `Serializable` parent class.
                 parent_serializable = serializable_bases[0]
-                fields = parent_serializable._meta.fields
+
+                if hasattr(parent_serializable, '_meta'):
+                    fields = parent_serializable._meta.fields
+                else:
+                    # This is a subclass of `Serializable` which has no
+                    # `fields`, likely intended for further subclassing.
+                    return super_new(cls, name, bases, attrs)
         else:
             # ensure that the `fields` property is a tuple of tuples to ensure
             # immutability.

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -554,3 +554,15 @@ def test_serializable_field_names_must_be_valid_identifiers(name):
             fields = (
                 (name, big_endian_int),
             )
+
+
+def test_serializable_inheritance_from_base_with_no_fields():
+    """
+    ensure that we can create base classes of the base `Serializable` without
+    declaring fields.
+    """
+    class ExtendedSerializable(Serializable):
+        pass
+
+    class FurtherExtendedSerializable(ExtendedSerializable):
+        pass


### PR DESCRIPTION
### What was wrong

Creating direct subclasses of `Serializable` without declaring fields was broken.

```python
class FancySerializable(Serializable):
    ... # extra stuff but no `fields` declaration
```

### How was it fixed

Fixed metaclass object to allow this.

#### Cute animal picture

![65ebc40201da4188901d846e74ffef5e](https://user-images.githubusercontent.com/824194/39263422-52fa8850-487f-11e8-97df-14a0c8651a16.jpg)
