### PR TITLE
Fix encoding/decoding of False for boolean sedes

### DIFF
--- a/rlp/sedes/boolean.py
+++ b/rlp/sedes/boolean.py
@@ -12,14 +12,14 @@ class Boolean:
             raise SerializationError('Can only serialize integers', obj)
 
         if obj is False:
-            return b'\x00'
+            return b''
         elif obj is True:
             return b'\x01'
         else:
             raise Exception("Invariant: no other options for boolean values")
 
     def deserialize(self, serial):
-        if serial == b'\x00':
+        if serial == b'':
             return False
         elif serial == b'\x01':
             return True

--- a/tests/test_boolean_serializer.py
+++ b/tests/test_boolean_serializer.py
@@ -11,7 +11,7 @@ from rlp.sedes import Boolean
     'value,expected',
     (
         (True, b'\x01'),
-        (False, b'\x00'),
+        (False, b''),
     ),
 )
 def test_boolean_serialize_values(value, expected):
@@ -39,7 +39,7 @@ def test_boolean_serialize_bad_values(value):
     'value,expected',
     (
         (b'\x01', True),
-        (b'\x00', False),
+        (b'', False),
     ),
 )
 def test_boolean_deserialization(value, expected):
@@ -50,7 +50,6 @@ def test_boolean_deserialization(value, expected):
 @pytest.mark.parametrize(
     'value',
     (
-        b'',
         b' ',
         b'\x02',
         b'\x00\x00',


### PR DESCRIPTION
The correct representation for 0 is the empty byte array, according to
https://github.com/ethereum/wiki/wiki/RLP:

"[...] positive RLP integers must be represented in big endian binary form with
no leading zeroes (thus making the integer value zero be equivalent to
the empty byte array)"