### PR TITLE
Give clearer message when trying to decode None

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
+.hypothesis
 .coverage
 .coverage.*
 .cache

--- a/rlp/codec.py
+++ b/rlp/codec.py
@@ -1,8 +1,9 @@
 import collections
 
 from eth_utils import (
-    int_to_big_endian,
     big_endian_to_int,
+    int_to_big_endian,
+    is_bytes,
 )
 
 from rlp.atomic import (
@@ -209,6 +210,8 @@ def decode(rlp, sedes=None, strict=True, **kwargs):
              `strict` is true
     :raises: :exc:`rlp.DeserializationError` if the deserialization fails
     """
+    if not is_bytes(rlp):
+        raise DecodingError('Can only decode RLP bytes, got type %s' % type(rlp).__name__, rlp)
     try:
         item, end = consume_item(rlp, 0)
     except IndexError:

--- a/tests/test_raw_sedes.py
+++ b/tests/test_raw_sedes.py
@@ -1,5 +1,5 @@
 import pytest
-from rlp import encode, decode, SerializationError
+from rlp import encode, decode, SerializationError, DecodingError
 from rlp.sedes import raw
 
 
@@ -15,19 +15,34 @@ serializable = (
 )
 
 
-not_serializable = (
-    0,
-    32,
-    ['asdf', ['fdsa', [5]]],
-    str
-)
-
-
 def test_serializable():
     for s in serializable:
         raw.serialize(s)
         code = encode(s, raw)
         assert s == decode(code, raw)
-    for s in not_serializable:
-        with pytest.raises(SerializationError):
-            raw.serialize(s)
+
+
+@pytest.mark.parametrize(
+    'rlp_data',
+    (
+        0,
+        32,
+        ['asdf', ['fdsa', [5]]],
+        str
+    ),
+)
+def test_invalid_serializations(rlp_data):
+    with pytest.raises(SerializationError):
+        raw.serialize(rlp_data)
+
+
+@pytest.mark.parametrize(
+    'rlp_data',
+    (
+        None,
+        'asdf',
+    ),
+)
+def test_invalid_deserializations(rlp_data):
+    with pytest.raises(DecodingError):
+        decode(rlp_data, raw)


### PR DESCRIPTION
Decoding a `None` value blows up deep down. This PR raises an exception early on to let you know that you passed an invalid value to `decode()`.