### PR TITLE
When pickling a BaseSerializable, set its _hash_cache to None

### DIFF
--- a/rlp/sedes/serializable.py
+++ b/rlp/sedes/serializable.py
@@ -236,6 +236,15 @@ class BaseSerializable(collections.Sequence):
     def __eq__(self, other):
         return isinstance(other, Serializable) and hash(self) == hash(other)
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        # The hash() builtin is not stable across processes
+        # (https://docs.python.org/3/reference/datamodel.html#object.__hash__), so we do this here
+        # to ensure pickled instances don't carry the cached hash() as that may cause issues like
+        # https://github.com/ethereum/py-evm/issues/1318
+        state['_hash_cache'] = None
+        return state
+
     _hash_cache = None
 
     def __hash__(self):


### PR DESCRIPTION
This is to prevent issues like https://github.com/ethereum/py-evm/issues/1318

Not sure if this is the direction we wanna go, but it occurred to me that one advantage of doing this instead of simply removing the caching is that it makes it less likely for somebody to accidentally reintroduce the issue by simply re-adding caching to `__hash__()`