### PR TITLE
Serializable class without declared fields parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ __pycache__/
 .Python
 env/
 .venv/
-venv/
+venv*
 build/
 develop-eggs/
 dist/

--- a/rlp/sedes/serializable.py
+++ b/rlp/sedes/serializable.py
@@ -383,7 +383,7 @@ class SerializableBase(abc.ABCMeta):
                 else:
                     # This is a subclass of `Serializable` which has no
                     # `fields`, likely intended for further subclassing.
-                    return super_new(cls, name, bases, attrs)
+                    fields = ()
         else:
             # ensure that the `fields` property is a tuple of tuples to ensure
             # immutability.

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -44,9 +44,14 @@ class RLPEmptyFieldsType(Serializable):
     fields = ()
 
 
+class RLPUndeclaredFieldsType(Serializable):
+    pass
+
+
 _type_1_a = RLPType1(5, b'a', (0, b''))
 _type_1_b = RLPType1(9, b'b', (2, b''))
 _type_2 = RLPType2(_type_1_a.copy(), [_type_1_a.copy(), _type_1_b.copy()])
+_type_undeclared_fields = RLPUndeclaredFieldsType()
 
 
 @pytest.fixture
@@ -148,6 +153,13 @@ def test_serializable_subclass_retains_field_info_from_parent():
     assert obj.field1 == 1
     assert obj.field2 == 2
     assert obj.field3 == 3
+
+
+def test_undeclared_fields_serializable_class():
+    assert RLPUndeclaredFieldsType.serialize(_type_undeclared_fields) == []
+    assert RLPUndeclaredFieldsType.deserialize(
+        RLPUndeclaredFieldsType.serialize(_type_undeclared_fields)
+    ) == _type_undeclared_fields
 
 
 def test_deserialization_for_custom_init_method():


### PR DESCRIPTION
# What was wrong
Fixes #101 

# How was it fixed
Previously, if the `fields` parameter was not declared in the class declaration, it was assumed that this class was gonna be used for further sub-classing and the resultant class didn't have `_meta` parameter in it. This has been changed, so that if the `fields` parameter wasn't declared, then they are by default set to an empty tuple.


# Cute Animal Picture
![](https://i.ytimg.com/vi/j2t_l5uTMRA/hqdefault.jpg)