### PR TITLE
fixed typo

### DIFF
--- a/rlp/sedes/serializable.py
+++ b/rlp/sedes/serializable.py
@@ -158,7 +158,7 @@ class BaseChangeset:
         if self.__state__ == ChangesetState.OPEN:
             self.__state__ = ChangesetState.CLOSED
         else:
-            raise ValueError("Cannot open Changeset which is not in the INITIALIZED state")
+            raise ValueError("Cannot close Changeset which is not in the OPEN state")
 
     def __enter__(self):
         if self.__state__ == ChangesetState.INITIALIZED:


### PR DESCRIPTION
### What was wrong?
 It seems to me that the error message `Cannot open Changeset which is not in the INITIALIZED state`
should be `Cannot close Changeset which is not in the OPEN state`. 
It seems this has been a result of copy/paste from https://github.com/ethereum/pyrlp/blob/0acc120334cf16f7138af13fc1e33654028926ca/rlp/sedes/serializable.py#L155

### How was it fixed?

fixed the typo.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://wweworld.info/wp-content/uploads/2018/06/962d61546f7055f6ebee7d7288b64b68--the-tiger-tiger-and-bunny.jpg)
