### PR TITLE
Fix deprecation warnings

### DIFF
--- a/rlp/lazy.py
+++ b/rlp/lazy.py
@@ -1,4 +1,4 @@
-from collections import Iterable, Sequence
+from collections.abc import Iterable, Sequence
 
 from .codec import consume_length_prefix, consume_payload
 from .exceptions import DecodingError

--- a/rlp/sedes/raw.py
+++ b/rlp/sedes/raw.py
@@ -3,7 +3,7 @@ A sedes that does nothing. Thus, everything that can be directly encoded by RLP
 is serializable. This sedes can be used as a placeholder when deserializing
 larger structures.
 """
-from collections import Sequence
+from collections.abc import Sequence
 
 from rlp.exceptions import SerializationError
 from rlp.atomic import Atomic


### PR DESCRIPTION
When using this library, the following deprecation warnings come up (e.g. when Trinity boots).

```
/home/cburgdorf/Documents/hacking/ef/trinity/venv/lib/python3.7/site-packages/rlp/sedes/raw.py:6: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  from collections import Sequence
/home/cburgdorf/Documents/hacking/ef/trinity/venv/lib/python3.7/site-packages/rlp/lazy.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working   
```

This PR changes the import into its recommended form.