### PR TITLE
Add Python 3.7 support in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,12 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-core
+  py37-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-core
   pypy3-core:
     <<: *common
     docker:
@@ -71,6 +77,12 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-doctest
+  py37-doctest:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-doctest
   pypy3-doctest:
     <<: *common
     docker:
@@ -91,10 +103,12 @@ workflows:
     jobs:
       - py35-core
       - py36-core
+      - py37-core
       - pypy3-core
 
       - py35-doctest
       - py36-doctest
+      - py37-doctest
       - pypy3-doctest
 
       - lint

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{35,36,py3}-core
-    py{35,36,py3}-doctest
+    py{35,36,37,py3}-core
+    py{35,36,37,py3}-doctest
     lint
 
 [flake8]
@@ -17,6 +17,7 @@ commands=
 basepython =
     py35: python3.5
     py36: python3.6
+    py37: python3.7
     pypy3: pypy3
 extras=
     test


### PR DESCRIPTION
The real reason for this PR is that my Python 3.6 setup is currently borked after I upgraded my OS but I guess we want to add Python 3.7 support anyway :)