### PR TITLE
Add Serializable.__repr__ that can be evaluated

### DIFF
--- a/rlp/sedes/serializable.py
+++ b/rlp/sedes/serializable.py
@@ -253,6 +253,13 @@ class BaseSerializable(collections.abc.Sequence):
 
         return self._hash_cache
 
+    def __repr__(self):
+        keyword_args = tuple("{}={!r}".format(k, v) for k, v in self.as_dict().items())
+        return "{}({})".format(
+            type(self).__name__,
+            ", ".join(keyword_args),
+        )
+
     @classmethod
     def serialize(cls, obj):
         try:

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -74,6 +74,11 @@ def rlp_obj(request):
     return request.param.copy()
 
 
+def test_serializeable_repr_evaluatable(rlp_obj):
+    evaluated = eval(repr(rlp_obj))
+    assert evaluated == rlp_obj
+
+
 @pytest.mark.parametrize(
     'rlptype,args,kwargs,exception_includes',
     (


### PR DESCRIPTION
The default `repr` for `Serializable` wasn't very helpful. So I added a default implementation that shows all fields.

Since it's entirely reasonable here, the `repr()` is valid python that can be evaluated. The test makes sure that the evaluated repr matches the original object.