### PR TITLE
add python 3.8 support to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-core
+  py38-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-core
   pypy3-core:
     <<: *common
     docker:
@@ -104,6 +110,7 @@ workflows:
       - py35-core
       - py36-core
       - py37-core
+      - py38-core
       - pypy3-core
 
       - py35-doctest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pyrlp
 
-[![Build Status](https://travis-ci.org/ethereum/pyrlp.svg?branch=develop)](https://travis-ci.org/ethereum/pyrlp)
+[![Build Status](https://circleci.com/gh/ethereum/pyrlp/tree/master.svg?style=svg)](https://circleci.com/gh/ethereum/pyrlp)
 [![Coverage Status](https://coveralls.io/repos/ethereum/pyrlp/badge.svg)](https://coveralls.io/r/ethereum/pyrlp)
 [![PyPI version](https://badge.fury.io/py/rlp.svg)](http://badge.fury.io/py/rlp)
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import (
 extras_require = {
     'test': [
         "pytest==5.3.0",
-        "tox",
+        "tox>=3.14.0,<3.15.0",
         "hypothesis==4.46.0",
     ],
     'lint': [

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,9 @@ from setuptools import (
 
 extras_require = {
     'test': [
-        "pytest==3.3.2",
-        "tox>=2.9.1,<3",
-        "hypothesis==3.56.5",
+        "pytest==5.3.0",
+        "tox",
+        "hypothesis==4.46.0",
     ],
     'lint': [
         "flake8==3.4.1",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{35,36,37,py3}-core
-    py{35,36,37,py3}-doctest
+    py{35,36,37,38,py3}-core
+    py{35,36,37,38,py3}-doctest
     lint
 
 [flake8]
@@ -18,6 +18,7 @@ basepython =
     py35: python3.5
     py36: python3.6
     py37: python3.7
+    py38: python3.8
     pypy3: pypy3
 extras=
     test


### PR DESCRIPTION
This PR adds python 3.8 testing to the CircleCI config. While I was verifying Python 3.8 support I ran into a few issues:

1) This project switched to CircleCI from TravisCI but didn't update the badge in the README. I've updated it here.
2) The CircleCI system is not submitting coverage to coveralls, so the coveralls link is very outdated. I don't have access to resolve this, but ideally this would be repaired so that combined coverage information is available again.
3) The pins for pytest and hypothesis were sufficiently old such that a problem occurred with a removed featured in `attrs`. I've updated the pins to be the latest versions, but since this isn't my project I don't know what the maintainers would prefer!

This PR was originally inspired by the fact that while `pyrlp` has merged a fix for a Python 3.8 incompatibility in https://github.com/ethereum/pyrlp/pull/113, that fix has not yet been released. If we can get a release after this PR is reviewed that would be great!