### PR TITLE
Use rust backend to speed up decoding / encoding

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,13 +58,6 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-core
-  pypy3-core:
-    <<: *common
-    docker:
-      - image: pypy:3-5.8.0
-        environment:
-          TOXENV: pypy3-core
-
   py35-doctest:
     <<: *common
     docker:
@@ -83,12 +76,6 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-doctest
-  pypy3-doctest:
-    <<: *common
-    docker:
-      - image: pypy:3-5.8.0
-        environment:
-          TOXENV: pypy3-doctest
 
   lint:
     <<: *common
@@ -104,11 +91,9 @@ workflows:
       - py35-core
       - py36-core
       - py37-core
-      - pypy3-core
 
       - py35-doctest
       - py36-doctest
       - py37-doctest
-      - pypy3-doctest
 
       - lint

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ target/
 
 # Editors
 *.swp
+.idea/
+
+# linting / type checking
+.mypy_cache/

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,9 @@ from setuptools import (
 
 extras_require = {
     'test': [
-        "pytest==3.3.2",
+        "pytest==5.4.3",
         "tox>=2.9.1,<3",
-        "hypothesis==3.56.5",
+        "hypothesis==5.19.0",
     ],
     'lint': [
         "flake8==3.4.1",

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
     setup_requires=['setuptools-markdown'],
     install_requires=[
         "eth-utils>=1.0.2,<2",
+        "rusty-rlp>=0.1.15, <0.2",
     ],
     extras_require=extras_require,
     license="MIT",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{35,36,37,py3}-core
-    py{35,36,37,py3}-doctest
+    py{35,36,37}-core
+    py{35,36,37}-doctest
     lint
 
 [flake8]
@@ -18,7 +18,6 @@ basepython =
     py35: python3.5
     py36: python3.6
     py37: python3.7
-    pypy3: pypy3
 extras=
     test
 whitelist_externals=make


### PR DESCRIPTION
### What was wrong

#### Current Performance

```
$ python tests/speed.py 
Block serializations / sec: 3224.00
Block deserializations / sec: 1907.96
TX serializations / sec: 41606.69
TX deserializations / sec: 23015.79
```

### How was it fixed

#### Performance with this PR

```
$ python tests/speed.py 
Block serializations / sec: 6188.00
Block deserializations / sec: 2194.96
TX serializations / sec: 72538.08
TX deserializations / sec: 28787.28
```

These numbers :point_up: where more impressive during development (and they still are depending on the specific benchmark) but I think I've lost some performance due to handling various edge cases. It's still faster though. That said, I believe there is still lots of room in [`rusty-rlp`](https://github.com/cburgdorf/rusty-rlp) to make things faster.

### TODO:

- [x] decide what to do about pypy
- [ ] decide what to do about ignored edge case
- [x] Ensure `rusty-rlp` produces mac and windows builds
- [x] decide if we can live without the recursive cache (it's disabled by default anyway)
- [x] Ensure [`rusty-rlp`](https://github.com/cburgdorf/rusty-rlp) has CI properly setup