### PR TITLE
Make rusty-rlp optional

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,36 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-core
+  py38-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-core
+  py35-rust-backend:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: py35-rust-backend
+  py36-rust-backend:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-rust-backend
+  py37-rust-backend:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-rust-backend
+  py38-rust-backend:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-rust-backend
   py35-doctest:
     <<: *common
     docker:
@@ -76,6 +106,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-doctest
+  py38-doctest:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-doctest
 
   lint:
     <<: *common
@@ -91,9 +127,16 @@ workflows:
       - py35-core
       - py36-core
       - py37-core
+      - py38-core
+
+      - py35-rust-backend
+      - py36-rust-backend
+      - py37-rust-backend
+      - py38-rust-backend
 
       - py35-doctest
       - py36-doctest
       - py37-doctest
+      - py38-doctest
 
       - lint

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ from setuptools import (
     find_packages,
 )
 
-
 extras_require = {
     'test': [
         "pytest==5.4.3",
@@ -28,6 +27,9 @@ extras_require = {
         "ipython",
         "twine",
     ],
+    'rust-backend': [
+        "rusty-rlp>=0.1.15, <0.2"
+    ]
 }
 
 
@@ -53,7 +55,6 @@ setup(
     setup_requires=['setuptools-markdown'],
     install_requires=[
         "eth-utils>=1.0.2,<2",
-        "rusty-rlp>=0.1.15, <0.2",
     ],
     extras_require=extras_require,
     license="MIT",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
-    py{35,36,37}-core
-    py{35,36,37}-doctest
+    py{35,36,37,38}-core
+    py{35,36,37,38}-rust-backend
+    py{35,36,37,38}-doctest
     lint
 
 [flake8]
@@ -14,12 +15,16 @@ usedevelop=True
 commands=
     core: py.test {posargs:tests/}
     doctest: py.test --doctest-glob='docs/*.rst' --doctest-modules docs rlp
+    rust-backend: py.test {posargs:tests/}
+
 basepython =
     py35: python3.5
     py36: python3.6
     py37: python3.7
+    py38: python3.8
 extras=
     test
+    rust-backend: rust-backend
 whitelist_externals=make
 
 [testenv:lint]


### PR DESCRIPTION
### What is wrong

We seem to have the following problem. Currently, we do not have 32-bit binaries for `rusty-rlp`. The reason for that is that Github Actions [does currently not support 32 bit platforms](https://github.community/t/does-github-actions-support-multiple-os-architectures/16526/2)

I had several people running into that problem. People will also run into this if they do have a 64 bit machine but installed a 32 bit Python [as it was the case here (solved)](https://github.com/cburgdorf/rusty-rlp/issues/15#issuecomment-691704680).

### How was it fixed

1. Only use `rusty-rlp` when it is explicitly installed e.g. `rlp[rust-backend]`

2. Add Python 3.8 support in CI

3. Add a job to test functionality with the rust backend