### PR TITLE
Update eth-utils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     include_package_data=True,
     setup_requires=['setuptools-markdown'],
     install_requires=[
-        "eth-utils>=1.0.2,<2",
+        "eth-utils>=2.0.0,<3",
     ],
     extras_require=extras_require,
     license="MIT",


### PR DESCRIPTION
* These are the changes, but will need to be merged after #134 *

`eth-utils` v2 no longer supports python 3.5. This PR bumps the eth-utils version.