### PR TITLE
Remove support for python 3.5, add support for python 3.9 and 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,12 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-core
+  py39-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-core
   py36-rust-backend:
     <<: *common
     docker:
@@ -76,6 +82,12 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-rust-backend
+  py39-rust-backend:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-rust-backend
   py36-doctest:
     <<: *common
     docker:
@@ -94,6 +106,12 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-doctest
+  py39-doctest:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-doctest
 
   lint:
     <<: *common
@@ -109,13 +127,16 @@ workflows:
       - py36-core
       - py37-core
       - py38-core
+      - py39-core
 
       - py36-rust-backend
       - py37-rust-backend
       - py38-rust-backend
+      - py39-rust-backend
 
       - py36-doctest
       - py37-doctest
       - py38-doctest
+      - py39-doctest
 
       - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,12 +40,6 @@ common: &common
         key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 jobs:
-  py35-core:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-core
   py36-core:
     <<: *common
     docker:
@@ -64,12 +58,6 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-core
-  py35-rust-backend:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-rust-backend
   py36-rust-backend:
     <<: *common
     docker:
@@ -88,12 +76,6 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-rust-backend
-  py35-doctest:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-doctest
   py36-doctest:
     <<: *common
     docker:
@@ -124,17 +106,14 @@ workflows:
   version: 2
   test:
     jobs:
-      - py35-core
       - py36-core
       - py37-core
       - py38-core
 
-      - py35-rust-backend
       - py36-rust-backend
       - py37-rust-backend
       - py38-rust-backend
 
-      - py35-doctest
       - py36-doctest
       - py37-doctest
       - py38-doctest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,12 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: py39-core
+  py310-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-core
   py36-rust-backend:
     <<: *common
     docker:
@@ -88,6 +94,12 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: py39-rust-backend
+  py310-rust-backend:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-rust-backend
   py36-doctest:
     <<: *common
     docker:
@@ -112,6 +124,12 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: py39-doctest
+  py310-doctest:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-doctest
 
   lint:
     <<: *common
@@ -128,15 +146,18 @@ workflows:
       - py37-core
       - py38-core
       - py39-core
+      - py310-core
 
       - py36-rust-backend
       - py37-rust-backend
       - py38-rust-backend
       - py39-rust-backend
+      - py310-rust-backend
 
       - py36-doctest
       - py37-doctest
       - py38-doctest
       - py39-doctest
+      - py310-doctest
 
       - lint

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,4 @@
 [pytest]
 addopts= --showlocals
-python_paths= .
 xfail_strict=true
 markers=benchmark

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 addopts= --showlocals
 python_paths= .
 xfail_strict=true
+markers=benchmark

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import (
 
 extras_require = {
     'test': [
-        "pytest==5.4.3",
+        "pytest>=6.2.5,<7",
         "tox>=2.9.1,<3",
         "hypothesis==5.19.0",
     ],
@@ -69,6 +69,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,9 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ extras_require = {
         "twine",
     ],
     'rust-backend': [
-        "rusty-rlp>=0.1.15, <0.2"
+        "rusty-rlp>=0.2.1, <0.3"
     ]
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{36,37,38,39}-core
-    py{36,37,38,39}-rust-backend
-    py{36,37,38,39}-doctest
+    py{36,37,38,39,310}-core
+    py{36,37,38,39,310}-rust-backend
+    py{36,37,38,39,310}-doctest
     lint
 
 [flake8]
@@ -22,6 +22,7 @@ basepython =
     py37: python3.7
     py38: python3.8
     py39: python3.9
+    py310: python3.10
 extras=
     test
     rust-backend: rust-backend

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{36,37,38}-core
-    py{36,37,38}-rust-backend
-    py{36,37,38}-doctest
+    py{36,37,38,39}-core
+    py{36,37,38,39}-rust-backend
+    py{36,37,38,39}-doctest
     lint
 
 [flake8]
@@ -21,6 +21,7 @@ basepython =
     py36: python3.6
     py37: python3.7
     py38: python3.8
+    py39: python3.9
 extras=
     test
     rust-backend: rust-backend

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{35,36,37,38}-core
-    py{35,36,37,38}-rust-backend
-    py{35,36,37,38}-doctest
+    py{36,37,38}-core
+    py{36,37,38}-rust-backend
+    py{36,37,38}-doctest
     lint
 
 [flake8]
@@ -18,7 +18,6 @@ commands=
     rust-backend: py.test {posargs:tests/}
 
 basepython =
-    py35: python3.5
     py36: python3.6
     py37: python3.7
     py38: python3.8


### PR DESCRIPTION
Thanks for the rusty-rlp version bump @cburgdorf!