### PR TITLE
convert .format to f-strings

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,11 +7,11 @@ Closes #
 
 ### Todo:
 
-- \[ \] Clean up commit history
+- [ ] Clean up commit history
 
-- \[ \] Add or update documentation related to these changes
+- [ ] Add or update documentation related to these changes
 
-- \[ \] Add entry to the [release notes](https://github.com/ethereum/pyrlp/blob/main/newsfragments/README.md)
+- [ ] Add entry to the [release notes](https://github.com/ethereum/pyrlp/blob/main/newsfragments/README.md)
 
 #### Cute Animal Picture
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: '.project-template|docs/conf.py'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.5.0
     hooks:
     -   id: check-yaml
     -   id: check-toml
@@ -30,6 +30,8 @@ repos:
     rev: 0.7.17
     hooks:
     -   id: mdformat
+        additional_dependencies:
+        -   mdformat-gfm
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.5.1
     hooks:

--- a/newsfragments/144.internal.rst
+++ b/newsfragments/144.internal.rst
@@ -1,0 +1,1 @@
+Convert ``.format`` strings to ``f-strings``

--- a/rlp/codec.py
+++ b/rlp/codec.py
@@ -57,7 +57,7 @@ except ImportError:
             payload = b"".join(encode_raw(x) for x in item)
             prefix_offset = 192  # list
         else:
-            msg = "Cannot encode object of type {0}".format(type(item).__name__)
+            msg = f"Cannot encode object of type {type(item).__name__}"
             raise EncodingError(msg, item)
 
         try:
@@ -73,7 +73,7 @@ except ImportError:
         except IndexError:
             raise DecodingError("RLP string too short", item)
         if end != len(item) and strict:
-            msg = "RLP string ends with {} superfluous bytes".format(len(item) - end)
+            msg = f"RLP string ends with {len(item) - end} superfluous bytes"
             raise DecodingError(msg, item)
 
         return result, per_item_rlp
@@ -350,5 +350,5 @@ def infer_sedes(obj):
         return boolean
     elif isinstance(obj, str):
         return text
-    msg = "Did not find sedes handling type {}".format(type(obj).__name__)
+    msg = f"Did not find sedes handling type {type(obj).__name__}"
     raise TypeError(msg)

--- a/rlp/exceptions.py
+++ b/rlp/exceptions.py
@@ -56,8 +56,8 @@ class ListSerializationError(SerializationError):
             assert index is not None
             assert element_exception is not None
             message = (
-                "Serialization failed because of element at index {} "
-                '("{}")'.format(index, str(element_exception))
+                f"Serialization failed because of element at index {index} "
+                f'("{str(element_exception)}")'
             )
         super(ListSerializationError, self).__init__(message, obj)
         self.index = index
@@ -82,13 +82,14 @@ class ObjectSerializationError(SerializationError):
                 field = None
                 message = (
                     "Serialization failed because of underlying list "
-                    '("{}")'.format(str(list_exception))
+                    f'("{str(list_exception)}")'
                 )
             else:
                 assert sedes is not None
                 field = sedes._meta.field_names[list_exception.index]
-                message = "Serialization failed because of field {} " '("{}")'.format(
-                    field, str(list_exception.element_exception)
+                message = (
+                    f"Serialization failed because of field {field} "
+                    f'("{str(list_exception.element_exception)}")'
                 )
         else:
             field = None
@@ -125,8 +126,8 @@ class ListDeserializationError(DeserializationError):
             assert index is not None
             assert element_exception is not None
             message = (
-                "Deserialization failed because of element at index {} "
-                '("{}")'.format(index, str(element_exception))
+                f"Deserialization failed because of element at index {index} "
+                f'("{str(element_exception)}")'
             )
         super(ListDeserializationError, self).__init__(message, serial)
         self.index = index
@@ -151,13 +152,14 @@ class ObjectDeserializationError(DeserializationError):
                 field = None
                 message = (
                     "Deserialization failed because of underlying list "
-                    '("{}")'.format(str(list_exception))
+                    f'("{str(list_exception)}")'
                 )
             else:
                 assert sedes is not None
                 field = sedes._meta.field_names[list_exception.index]
-                message = "Deserialization failed because of field {} " '("{}")'.format(
-                    field, str(list_exception.element_exception)
+                message = (
+                    f"Deserialization failed because of field {field} "
+                    f'("{str(list_exception.element_exception)}")'
                 )
         super(ObjectDeserializationError, self).__init__(message, serial)
         self.sedes = sedes

--- a/rlp/sedes/big_endian_int.py
+++ b/rlp/sedes/big_endian_int.py
@@ -25,7 +25,7 @@ class BigEndianInt(object):
             raise SerializationError("Can only serialize integers", obj)
         if self.length is not None and obj >= 256**self.length:
             raise SerializationError(
-                "Integer too large (does not fit in {self.length} bytes)",
+                f"Integer too large (does not fit in {self.length} bytes)",
                 obj,
             )
         if obj < 0:

--- a/rlp/sedes/big_endian_int.py
+++ b/rlp/sedes/big_endian_int.py
@@ -25,7 +25,7 @@ class BigEndianInt(object):
             raise SerializationError("Can only serialize integers", obj)
         if self.length is not None and obj >= 256**self.length:
             raise SerializationError(
-                "Integer too large (does not fit in {} " "bytes)".format(self.length),
+                "Integer too large (does not fit in {self.length} bytes)",
                 obj,
             )
         if obj < 0:

--- a/rlp/sedes/binary.py
+++ b/rlp/sedes/binary.py
@@ -44,9 +44,7 @@ class Binary(object):
 
     def serialize(self, obj):
         if not Binary.is_valid_type(obj):
-            raise SerializationError(
-                "Object is not a serializable ({})".format(type(obj)), obj
-            )
+            raise SerializationError(f"Object is not a serializable ({type(obj)})", obj)
 
         if not self.is_valid_length(len(obj)):
             raise SerializationError("Object has invalid length", obj)
@@ -55,15 +53,15 @@ class Binary(object):
 
     def deserialize(self, serial):
         if not isinstance(serial, Atomic):
-            m = "Objects of type {} cannot be deserialized"
-            raise DeserializationError(m.format(type(serial).__name__), serial)
+            raise DeserializationError(
+                f"Objects of type {type(serial).__name__} cannot be deserialized",
+                serial,
+            )
 
         if self.is_valid_length(len(serial)):
             return serial
         else:
-            raise DeserializationError(
-                "{} has invalid length".format(type(serial)), serial
-            )
+            raise DeserializationError(f"{type(serial)} has invalid length", serial)
 
 
 binary = Binary()

--- a/rlp/sedes/lists.py
+++ b/rlp/sedes/lists.py
@@ -123,10 +123,7 @@ class CountableList(object):
 
         if self.max_length is not None and len(obj) > self.max_length:
             raise ListSerializationError(
-                "Too many elements ({}, allowed {})".format(
-                    len(obj),
-                    self.max_length,
-                ),
+                f"Too many elements ({len(obj)}, allowed {self.max_length})",
                 obj=obj,
             )
 
@@ -145,7 +142,7 @@ class CountableList(object):
         for index, element in enumerate(serial):
             if self.max_length is not None and index >= self.max_length:
                 raise ListDeserializationError(
-                    "Too many elements (more than {})".format(self.max_length),
+                    f"Too many elements (more than {self.max_length})",
                     serial=serial,
                 )
 

--- a/rlp/sedes/serializable.py
+++ b/rlp/sedes/serializable.py
@@ -37,24 +37,22 @@ def _get_duplicates(values):
 def validate_args_and_kwargs(args, kwargs, arg_names, allow_missing=False):
     duplicate_arg_names = _get_duplicates(arg_names)
     if duplicate_arg_names:
-        raise TypeError(
-            "Duplicate argument names: {0}".format(sorted(duplicate_arg_names))
-        )
+        raise TypeError(f"Duplicate argument names: {sorted(duplicate_arg_names)}")
 
     needed_kwargs = arg_names[len(args) :]
     used_kwargs = set(arg_names[: len(args)])
 
     duplicate_kwargs = used_kwargs.intersection(kwargs.keys())
     if duplicate_kwargs:
-        raise TypeError("Duplicate kwargs: {0}".format(sorted(duplicate_kwargs)))
+        raise TypeError(f"Duplicate kwargs: {sorted(duplicate_kwargs)}")
 
     unknown_kwargs = set(kwargs.keys()).difference(arg_names)
     if unknown_kwargs:
-        raise TypeError("Unknown kwargs: {0}".format(sorted(unknown_kwargs)))
+        raise TypeError(f"Unknown kwargs: {sorted(unknown_kwargs)}")
 
     missing_kwargs = set(needed_kwargs).difference(kwargs.keys())
     if not allow_missing and missing_kwargs:
-        raise TypeError("Missing kwargs: {0}".format(sorted(missing_kwargs)))
+        raise TypeError(f"Missing kwargs: {sorted(missing_kwargs)}")
 
 
 @to_tuple
@@ -180,7 +178,7 @@ class BaseChangeset:
 def Changeset(obj, changes):
     namespace = {name: ChangesetField(name) for name in obj._meta.field_names}
     cls = type(
-        "{0}Changeset".format(obj.__class__.__name__),
+        f"{obj.__class__.__name__}Changeset",
         (BaseChangeset,),
         namespace,
     )
@@ -196,11 +194,9 @@ class BaseSerializable(collections.abc.Sequence):
 
         if len(field_values) != len(self._meta.field_names):
             raise TypeError(
-                "Argument count mismatch. expected {0} - got {1} - missing {2}".format(
-                    len(self._meta.field_names),
-                    len(field_values),
-                    ",".join(self._meta.field_names[len(field_values) :]),
-                )
+                f"Argument count mismatch. expected {len(self._meta.field_names)} - "
+                f"got {len(field_values)} - "
+                f"missing {','.join(self._meta.field_names[len(field_values) :])}"
             )
 
         for value, attr in zip(field_values, self._meta.field_attrs):
@@ -227,7 +223,7 @@ class BaseSerializable(collections.abc.Sequence):
         elif isinstance(idx, str):
             return getattr(self, idx)
         else:
-            raise IndexError("Unsupported type for __getitem__: {0}".format(type(idx)))
+            raise IndexError(f"Unsupported type for __getitem__: {type(idx)}")
 
     def __len__(self):
         return len(self._meta.fields)
@@ -253,11 +249,8 @@ class BaseSerializable(collections.abc.Sequence):
         return self._hash_cache
 
     def __repr__(self):
-        keyword_args = tuple("{}={!r}".format(k, v) for k, v in self.as_dict().items())
-        return "{}({})".format(
-            type(self).__name__,
-            ", ".join(keyword_args),
-        )
+        keyword_args = tuple(f"{k}={v!r}" for k, v in self.as_dict().items())
+        return f"{type(self).__name__}({', '.join(keyword_args)})"
 
     @classmethod
     def serialize(cls, obj):
@@ -403,8 +396,7 @@ class SerializableBase(abc.ABCMeta):
         if duplicate_field_names:
             raise TypeError(
                 "The following fields are duplicated in the `fields` "
-                "declaration: "
-                "{0}".format(",".join(sorted(duplicate_field_names)))
+                f"declaration: {','.join(sorted(duplicate_field_names))}"
             )
 
         # check that field names are valid identifiers
@@ -415,11 +407,8 @@ class SerializableBase(abc.ABCMeta):
         }
         if invalid_field_names:
             raise TypeError(
-                "The following field names are not valid python identifiers: {0}".format(  # noqa: E501
-                    ",".join(
-                        "`{0}`".format(item) for item in sorted(invalid_field_names)
-                    )
-                )
+                "The following field names are not valid python identifiers: "
+                f"{','.join(f'`{item}`' for item in sorted(invalid_field_names))}"
             )
 
         # extract all of the fields from parent `Serializable` classes.
@@ -437,8 +426,7 @@ class SerializableBase(abc.ABCMeta):
             raise TypeError(
                 "Subclasses of `Serializable` **must** contain a full superset "
                 "of the fields defined in their parent classes.  The following "
-                "fields are missing: "
-                "{0}".format(",".join(sorted(missing_fields)))
+                f"fields are missing: {','.join(sorted(missing_fields))}"
             )
 
         # the actual field values are stored in separate *private* attributes.

--- a/rlp/sedes/text.py
+++ b/rlp/sedes/text.py
@@ -49,9 +49,7 @@ class Text:
 
     def serialize(self, obj):
         if not self.is_valid_type(obj):
-            raise SerializationError(
-                "Object is not a serializable ({})".format(type(obj)), obj
-            )
+            raise SerializationError(f"Object is not a serializable ({type(obj)})", obj)
 
         if not self.is_valid_length(len(obj)):
             raise SerializationError("Object has invalid length", obj)
@@ -60,8 +58,10 @@ class Text:
 
     def deserialize(self, serial):
         if not isinstance(serial, Atomic):
-            m = "Objects of type {} cannot be deserialized"
-            raise DeserializationError(m.format(type(serial).__name__), serial)
+            raise DeserializationError(
+                f"Objects of type {type(serial).__name__} cannot be deserialized",
+                serial,
+            )
 
         try:
             text_value = serial.decode(self.encoding)
@@ -71,9 +71,7 @@ class Text:
         if self.is_valid_length(len(text_value)):
             return text_value
         else:
-            raise DeserializationError(
-                "{} has invalid length".format(type(serial)), serial
-            )
+            raise DeserializationError(f"{type(serial)} has invalid length", serial)
 
 
 text = Text()

--- a/tests/test_big_endian.py
+++ b/tests/test_big_endian.py
@@ -144,19 +144,19 @@ def perf():
     for _ in range(100000):
         for i in random_integers:
             packl(i)
-    print("packl elapsed {}".format(time.time() - st))
+    print(f"packl elapsed {time.time() - st}")
 
     st = time.time()
     for _ in range(100000):
         for i in random_integers:
             packl_ctypes(i)
-    print("ctypes elapsed {}".format(time.time() - st))
+    print(f"ctypes elapsed {time.time() - st}")
 
     st = time.time()
     for _ in range(100000):
         for i in random_integers:
             int_to_big_endian(i)
-    print("py elapsed {}".format(time.time() - st))
+    print(f"py elapsed {time.time() - st}")
 
 
 if __name__ == "__main__":

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -65,17 +65,17 @@ with open("tests/rlptest.json") as rlptest_file:
 
 @pytest.mark.parametrize("name, in_out", test_pieces)
 def test_encode(name, in_out):
-    msg_format = "Test {} failed (encoded {} to {} instead of {})"
     data = in_out["in"]
     result = encode_hex(encode(data)).lower()
     expected = in_out["out"].lower()
     if result != expected:
-        pytest.fail(msg_format.format(name, data, result, expected))
+        pytest.fail(
+            f"Test {name} failed (encoded {data} to {result} instead of {expected})"
+        )
 
 
 @pytest.mark.parametrize("name, in_out", test_pieces)
 def test_decode(name, in_out):
-    msg_format = "Test {} failed (decoded {} to {} instead of {})"
     rlp_string = decode_hex(in_out["out"])
     decoded = decode(rlp_string)
     with pytest.raises(DecodingError):
@@ -89,4 +89,6 @@ def test_decode(name, in_out):
     assert compare_nested(data, decode(rlp_string, sedes))
 
     if not compare_nested(data, expected):
-        pytest.fail(msg_format.format(name, rlp_string, decoded, expected))
+        pytest.fail(
+            f"Test {name} failed (decoded {rlp_string} to {decoded} instead of {expected})"  # noqa: E501
+        )

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -633,8 +633,9 @@ def test_serializable_multiple_inheritance_requires_all_parent_fields():
     ),
 )
 def test_serializable_field_names_must_be_valid_identifiers(name):
-    msg = "not valid python identifiers: `{0}`".format(re.escape(name))
-    with pytest.raises(TypeError, match=msg):
+    with pytest.raises(
+        TypeError, match=f"not valid python identifiers: `{re.escape(name)}`"
+    ):
 
         class Klass(Serializable):
             fields = ((name, big_endian_int),)


### PR DESCRIPTION
### What was wrong?

 - Lib still used old-style `.format` strings. 
 - mdformat markdown linter did not have the github-flavored extension, so messed with checkboxes

### How was it fixed?

 - Converted to f-strings.
 - Added github flavoring to mdformat
 - Bumped pre-commit hooks version to latest

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/pyrlp/blob/main/newsfragments/README.md)
- [x] Add or update documentation related to these changes

#### Cute Animal Picture

![image](https://github.com/ethereum/pyrlp/assets/5199899/0805eb3e-f3db-4042-ab2c-c17b4ddea9b4)
