### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ python -m pip install rlp
 
 ## Developer Setup
 
-If you would like to hack on pyrlp, please check out the [Snake Charmers
-Tactical Manual](https://github.com/ethereum/snake-charmers-tactical-manual)
+If you would like to hack on pyrlp, please check out the 
+[Snake Charmers Tactical Manual](https://github.com/ethereum/snake-charmers-tactical-manual)
 for information on how we do:
 
 - Testing


### PR DESCRIPTION
Between "Snake" and "Charmers" there was a 0x0A (LF) character instead of  0x20 (SPACE). This may break some builds when setup tools try to parse long_description_markdown_filename.

### What was wrong?

Related to Issue #
Closes #

### How was it fixed?
Replaced LF with SPACE.

### Todo:

- [ ] Clean up commit history

- [ ] Add or update documentation related to these changes

- [ ] Add entry to the [release notes](https://github.com/ethereum/pyrlp/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
