### PR TITLE
fix: accept memoryview in decode and decode_lazy

### DIFF
--- a/rlp/codec.py
+++ b/rlp/codec.py
@@ -290,6 +290,9 @@ def decode(rlp, sedes=None, strict=True, recursive_cache=False, **kwargs):
              item and `strict` is true
     :raises: :exc:`rlp.DeserializationError` if the deserialization fails
     """
+    if isinstance(rlp, memoryview):
+        rlp = bytes(rlp)
+
     if not is_bytes(rlp):
         raise DecodingError(
             "Can only decode RLP bytes, got type %s" % type(rlp).__name__, rlp

--- a/rlp/lazy.py
+++ b/rlp/lazy.py
@@ -39,6 +39,9 @@ def decode_lazy(rlp, sedes=None, **sedes_kwargs):
     :returns: either the already decoded and deserialized object (if encoded as
               a string) or an instance of :class:`rlp.LazyList`
     """
+    if isinstance(rlp, memoryview):
+        rlp = bytes(rlp)
+
     item, end = consume_item_lazy(rlp, 0)
     if end != len(rlp):
         raise DecodingError("RLP length prefix announced wrong length", rlp)

--- a/tests/core/test_memoryview.py
+++ b/tests/core/test_memoryview.py
@@ -1,0 +1,24 @@
+from rlp import (
+    decode,
+    decode_lazy,
+    encode,
+)
+
+
+def test_memoryview():
+    e = encode(b"abc")
+    expected = decode(e)
+    actual = decode(memoryview(e))
+    assert actual == expected
+
+
+def test_memoryview_lazy():
+    e = encode(b"abc")
+    expected = decode(e)
+    actual = decode_lazy(memoryview(e))
+    assert expected == actual
+
+
+def test_memoryview_nested_list():
+    e = encode([b"cat", b"dog", [b"nested", b""]])
+    assert decode(memoryview(e)) == decode(e)


### PR DESCRIPTION
Closes #115.

`rlp.decode` rejected `memoryview` objects — `is_bytes` (from `eth_utils`) only accepts `bytes`/`bytearray`, so `rlp.decode(memoryview(encoded))` raised `DecodingError: Can only decode RLP bytes, got type memoryview`.

Simply widening the type check is not enough in the pure-Python backend: the codec concatenates slices of the input (`prefix + item`, `rlp[i:i+1] + len_prefix`), and `memoryview` does not support `+`, so `decode_lazy(memoryview(...))` raised `TypeError: unsupported operand type(s) for +: 'memoryview' and 'memoryview'`.

**Fix:** normalize a `memoryview` input to `bytes` at the top of both `decode` and `decode_lazy`, mirroring the existing `bytearray` handling. This makes `memoryview` a first-class input like `bytearray` (which already worked in both paths), works for both the pure-Python and `rusty_rlp` backends, and round-trips for nested lists and with a sedes.

**Tests:** added `tests/core/test_memoryview.py`, mirroring `test_bytearray.py` (covers `decode`, `decode_lazy`, and a nested list). All three fail on `main` and pass with this change.
